### PR TITLE
chore: fix build pipeline

### DIFF
--- a/.github/scripts/install-vs-components.ps1
+++ b/.github/scripts/install-vs-components.ps1
@@ -1,0 +1,17 @@
+Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+$InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+$componentsToInstall= @(
+"Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+"Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
+"Microsoft.VisualStudio.Component.VC.v141.MFC"
+"Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
+"Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+)
+[string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+$Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+# should be run twice
+$process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+$process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -39,24 +39,7 @@ jobs:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: Install components
-      run: |
-              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-              $componentsToInstall= @(
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
-                "Microsoft.VisualStudio.Component.VC.v141.MFC"
-                "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
-              )
-              [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
-              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-              # should be run twice
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+      run: .\.github\scripts\install-vs-components.ps1
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -111,25 +94,8 @@ jobs:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: Install components
-      run: |
-              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-              $componentsToInstall= @(
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
-                "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
-                "Microsoft.VisualStudio.Component.VC.v141.MFC"
-                "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
-                "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
-              )
-              [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
-              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-              # should be run twice
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-    
+      run: .\.github\scripts\install-vs-components.ps1
+
     - name: Install sonar-scanner and build-wrapper
       uses: SonarSource/sonarcloud-github-c-cpp@v2
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -161,24 +161,6 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=x64 ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Code signing
-      env:
-        CERTIFICATE: ${{ secrets.CERTIFICATE }}
-        CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
-        BINARY32: "distrib/x86/Acrolinx.Sidebar.SDK.dll"
-        BINARY64: "distrib/x64/Acrolinx.Sidebar.SDK.dll"
-        SIGNTOOL: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
-      if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
-      shell: powershell
-      run : |
-        $ErrorActionPreference = 'stop'
-        $env:CERTIFICATE | Out-File -FilePath .\Certificate
-        certutil -decode Certificate AcrolinxCertificate.pfx
-        & $env:SIGNTOOL sign /f AcrolinxCertificate.pfx /p $env:CERTIFICATE_PASSWORD /tr http://timestamp.digicert.com /td sha256 /fd sha256 $env:BINARY32
-        & $env:SIGNTOOL sign /f AcrolinxCertificate.pfx /p $env:CERTIFICATE_PASSWORD /tr http://timestamp.digicert.com /td sha256 /fd sha256 $env:BINARY64
-        del .\Certificate
-        del AcrolinxCertificate.pfx
-
     # Update .nuspec (Nuget Specification) with version number
     - name: Patch version in nuget spec
       run: |

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -38,6 +38,26 @@ jobs:
       env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
+    - name: Install components
+      run: |
+              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+              $componentsToInstall= @(
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
+                "Microsoft.VisualStudio.Component.VC.v141.MFC"
+                "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+              )
+              [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+              # should be run twice
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
@@ -89,6 +109,26 @@ jobs:
       uses: microsoft/setup-msbuild@v2.0.0 
       env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+    - name: Install components
+      run: |
+              Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+              $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+              $componentsToInstall= @(
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+                "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre"
+                "Microsoft.VisualStudio.Component.VC.v141.MFC"
+                "Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.MFC"
+                "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+              )
+              [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+              $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+              # should be run twice
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+              $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
     
     - name: Install sonar-scanner and build-wrapper
       uses: SonarSource/sonarcloud-github-c-cpp@v2


### PR DESCRIPTION
Our builds start failing as MS decides to remove older components from Visual Studio runner image
https://github.com/actions/runner-images/issues/9701

So we need to install them before building our job

- Install Visual C++ Components
- Remove old code signing code 