### PR TITLE
Remove deprecated reviewers Dependabot config option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
   - package-ecosystem: "nuget"
     directory: "/Acrolinx.Sidebar.SDK/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
   - package-ecosystem: "npm"
     directory: "/Acrolinx.Sidebar.SDK/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
     versioning-strategy: increase


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/